### PR TITLE
Stop consuming when parent context is cancelled

### DIFF
--- a/consumersingle.go
+++ b/consumersingle.go
@@ -178,6 +178,12 @@ func (c *consumerSingle[T]) iterationRecords(ctx context.Context, cl committer, 
 			return fmt.Errorf("wait group failed: %w", err)
 		}
 
+		// If the parent context was cancelled, the errGroup won't return any error, so we need to check the parent context
+		// and return the error if not nil.
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("main consumer context error: %w", err)
+		}
+
 		// commit all records in group
 		records := c.Group.AllRecords()
 		records, _ = c.PartitionHandler.IsRevokedRecordBatch(records)

--- a/consumersingle_test.go
+++ b/consumersingle_test.go
@@ -3,8 +3,10 @@ package wkafka
 import (
 	"context"
 	"errors"
+	"fmt"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kgo"
@@ -162,4 +164,80 @@ func TestConsumerSingle_iterationConcurrent(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConsumerSingle_iterationRecords(t *testing.T) {
+	t.Run("consumer stops when parent context is cancelled", func(t *testing.T) {
+		processed := make([]any, 0, 20)
+		cs := consumerSingle[any]{
+			customer: &customer[any]{
+				Cfg: &ConsumerConfig{
+					Concurrent: ConcurrentConfig{
+						Process: 20,
+					},
+					Skip:                           make(map[string]map[int32]OffsetConfig),
+					RecoverAfterProcessingError:    true,
+					ProcessPartitionsIndependently: true,
+				},
+				Skip: func(cfg *ConsumerConfig, r *kgo.Record) bool {
+					return false
+				},
+				Decode: func(raw []byte, r *kgo.Record) (any, error) {
+					return raw, nil
+				},
+				Logger: LogNoop{},
+			},
+			Group: newGroupMix(100, 20),
+			PartitionHandler: &partitionHandler{
+				logger: LogNoop{},
+			},
+			Process: func(ctx context.Context, msg any) error {
+				processed = append(processed, msg)
+				time.Sleep(time.Second)
+
+				return nil
+			},
+		}
+
+		fetch := kgo.Fetches{
+			{
+				Topics: []kgo.FetchTopic{
+					{
+						Topic: "test",
+						Partitions: []kgo.FetchPartition{
+							{
+								Partition: 0,
+								Records:   make([]*kgo.Record, 30),
+							},
+						},
+					},
+				},
+			},
+		}
+
+		for i := range 30 {
+			fetch[0].Topics[0].Partitions[0].Records[i] = &kgo.Record{
+				Topic: "test",
+				Value: []byte(fmt.Sprintf("%d", i)),
+			}
+		}
+
+		com := mockCommitter{
+			committedOffsets: []int64{},
+		}
+
+		ctx, cancel := context.WithCancel(t.Context())
+		go func() {
+			time.Sleep(500 * time.Millisecond)
+			cancel()
+		}()
+
+		err := cs.iterationConcurrent(ctx, &com, fetch)
+
+		require.Error(t, err)
+		require.ErrorContains(t, err, "main consumer context error")
+
+		require.LessOrEqual(t, len(processed), 20, "at most 20 events should be processed")
+		require.Len(t, com.committedOffsets, 0, "no events should be committed")
+	})
 }


### PR DESCRIPTION
Do not commit any messages after parent context was cancelled