### PR TITLE
Recover after error only when processing partitions independently

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -72,6 +72,7 @@ type ConsumerConfig struct {
 	// RecoverAfterProcessingError is a configuration of expected consumer behavior after processing returns any error.
 	// If it is true, any error besides ErrFatal will be just logged and won't cause a service restart.
 	// It is false as a default to ensure backwards compatibility.
+	// It works only when ProcessPartitionsIndependently is also true.
 	RecoverAfterProcessingError bool `cfg:"recover_after_processing_error" json:"recover_after_processing_error"`
 	// ProcessPartitionsIndependently configures a consumer to process partitions independently. This means that if we
 	// consume from multiple topics and partitions at the same time and we get a processing error on the record from

--- a/consumersingle.go
+++ b/consumersingle.go
@@ -107,9 +107,17 @@ func (c *consumerSingle[T]) iterationConcurrent(ctx context.Context, cl committe
 				}
 
 				err := c.iterationRecords(ctx, cl, singlePartitionFetch.RecordIter())
-				if err != nil {
-					return fmt.Errorf("error while processing partition: %w", err)
+
+				// We don't want to restart the service and only continue to the next partition.
+				if err != nil && c.Cfg.RecoverAfterProcessingError && !errors.Is(err, ErrFatal) {
+					c.Logger.Warn("skipping to the next partition",
+						"error", err,
+					)
+
+					continue
 				}
+
+				return fmt.Errorf("error while processing partition: %w", err)
 			}
 		}
 	}
@@ -166,15 +174,6 @@ func (c *consumerSingle[T]) iterationRecords(ctx context.Context, cl committer, 
 		}
 
 		if err := errGroup.Wait(); err != nil {
-			// We don't want to restart the service and only continue to the next partition or batch of records.
-			if c.Cfg.RecoverAfterProcessingError && !errors.Is(err, ErrFatal) {
-				c.Logger.Warn("not committing the rest of the records",
-					"error", err,
-				)
-
-				return nil
-			}
-
 			return fmt.Errorf("wait group failed: %w", err)
 		}
 

--- a/consumersingle.go
+++ b/consumersingle.go
@@ -107,17 +107,18 @@ func (c *consumerSingle[T]) iterationConcurrent(ctx context.Context, cl committe
 				}
 
 				err := c.iterationRecords(ctx, cl, singlePartitionFetch.RecordIter())
+				if err != nil {
+					// We don't want to restart the service and only continue to the next partition.
+					if c.Cfg.RecoverAfterProcessingError && !errors.Is(err, ErrFatal) {
+						c.Logger.Warn("skipping to the next partition",
+							"error", err,
+						)
 
-				// We don't want to restart the service and only continue to the next partition.
-				if err != nil && c.Cfg.RecoverAfterProcessingError && !errors.Is(err, ErrFatal) {
-					c.Logger.Warn("skipping to the next partition",
-						"error", err,
-					)
+						continue
+					}
 
-					continue
+					return fmt.Errorf("error while processing partition: %w", err)
 				}
-
-				return fmt.Errorf("error while processing partition: %w", err)
 			}
 		}
 	}

--- a/consumersingle_test.go
+++ b/consumersingle_test.go
@@ -95,8 +95,9 @@ func TestConsumerSingle_iterationConcurrent(t *testing.T) {
 						Concurrent: ConcurrentConfig{
 							Process: 20,
 						},
-						Skip:                        make(map[string]map[int32]OffsetConfig),
-						RecoverAfterProcessingError: true,
+						Skip:                           make(map[string]map[int32]OffsetConfig),
+						ProcessPartitionsIndependently: true,
+						RecoverAfterProcessingError:    true,
 					},
 					Skip: func(cfg *ConsumerConfig, r *kgo.Record) bool {
 						return false
@@ -176,7 +177,7 @@ func TestConsumerSingle_iterationRecords(t *testing.T) {
 						Process: 20,
 					},
 					Skip:                           make(map[string]map[int32]OffsetConfig),
-					RecoverAfterProcessingError:    true,
+					RecoverAfterProcessingError:    false,
 					ProcessPartitionsIndependently: true,
 				},
 				Skip: func(cfg *ConsumerConfig, r *kgo.Record) bool {


### PR DESCRIPTION
If we want to recover after error, we need to process partitions independently, so we can continue to the next partition after error.