### PR TITLE
feat: expose ProduceSync results

### DIFF
--- a/client.go
+++ b/client.go
@@ -391,6 +391,10 @@ func (c *Client) ProduceRaw(ctx context.Context, records []*kgo.Record) error {
 	return nil
 }
 
+func (c *Client) ProduceSync(ctx context.Context, records []*kgo.Record) kgo.ProduceResults {
+	return c.Kafka.ProduceSync(ctx, records...)
+}
+
 // Admin returns an admin client to manage kafka.
 func (c *Client) Admin() *kadm.Client {
 	return kadm.NewClient(c.Kafka)


### PR DESCRIPTION
To be able to tell which kafka messages were produced successfully and which not we need to expose kgo.ProduceResults type to users.